### PR TITLE
feat(payments): harden PayMongo checkout and webhooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ JWT_AUTH_HEADER_TYPE=Bearer
 # --- Payment Gateways ---
 PAYMONGO_SECRET_KEY=sk_test_placeholder
 PAYMONGO_WEBHOOK_SECRET=wh_placeholder
+PAYMONGO_SUCCESS_URL=http://localhost:3000/orders/payment/success
+PAYMONGO_CANCEL_URL=http://localhost:3000/orders/payment/cancelled
+PAYMONGO_USE_MOCK=True
 
 # --- API Settings ---
 API_V1_SUNSET=2026-12-31

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ cp .env.production.example .env
 
 Then update secrets in `.env` (for example `SECRET_KEY` and database credentials).
 
+Location services also require provider keys for address search and road distance estimates:
+
+```env
+GEOAPIFY_API_KEY=your_geoapify_api_key_here
+OPENROUTESERVICE_API_KEY=your_openrouteservice_api_key_here
+```
+
+Do not commit real API keys. See `docs/api/locations_api.md` for the location endpoints and delivery fee flow.
+
 ## Settings Modules
 
 - Dev: `config.settings.dev`

--- a/apps/orders/views.py
+++ b/apps/orders/views.py
@@ -200,7 +200,11 @@ class CheckoutView(APIView):
             else:
                 # Schedule auto-cancellation in 5 minutes (for manual acceptance)
                 from .tasks import auto_cancel_stale_order
-                auto_cancel_stale_order.apply_async((str(order.id),), countdown=600)
+                transaction.on_commit(
+                    lambda: auto_cancel_stale_order.apply_async(
+                        (str(order.id),), countdown=600
+                    )
+                )
 
             return Response({
                 "status": "success",

--- a/apps/orders/views.py
+++ b/apps/orders/views.py
@@ -219,11 +219,13 @@ class CheckoutView(APIView):
             # Call PayMongo API to generate a checkout link
             paymongo_response = PayMongoService.create_checkout_session(
                 amount=order.total_amount,
-                description=f"Sarig Order {order.id}"
+                description=f"Sarig Order {order.id}",
+                order_id=order.id,
             )
 
             transaction_record.external_transaction_id = paymongo_response['id']
-            transaction_record.save()
+            transaction_record.provider_raw_response = paymongo_response.get("raw")
+            transaction_record.save(update_fields=["external_transaction_id", "provider_raw_response", "updated_at"])
 
             return Response({
                 "status": "pending",

--- a/apps/payments/migrations/0003_paymentstatus_expired.py
+++ b/apps/payments/migrations/0003_paymentstatus_expired.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("payments", "0002_paymenttransaction_payment_id"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="paymenttransaction",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("PENDING", "Pending/Awaiting Payment"),
+                    ("AUTHORIZED", "Authorized (Funds held, not captured)"),
+                    ("SUCCESS", "Payment Successful"),
+                    ("FAILED", "Payment Failed"),
+                    ("EXPIRED", "Payment Expired"),
+                    ("REFUNDED", "Payment Refunded"),
+                ],
+                db_index=True,
+                default="PENDING",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/apps/payments/models.py
+++ b/apps/payments/models.py
@@ -15,6 +15,7 @@ class PaymentStatus(models.TextChoices):
     AUTHORIZED = "AUTHORIZED", "Authorized (Funds held, not captured)"
     SUCCESS = "SUCCESS", "Payment Successful"
     FAILED = "FAILED", "Payment Failed"
+    EXPIRED = "EXPIRED", "Payment Expired"
     REFUNDED = "REFUNDED", "Payment Refunded"
 
 

--- a/apps/payments/services.py
+++ b/apps/payments/services.py
@@ -1,7 +1,10 @@
 import os
+from decimal import Decimal
+
 import requests
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+
 
 class PayMongoService:
     BASE_URL = "https://api.paymongo.com/v1"
@@ -23,23 +26,22 @@ class PayMongoService:
             "Authorization": f"Basic {auth}"
         }
 
+    @staticmethod
+    def _to_centavos(amount):
+        return int(Decimal(str(amount)) * 100)
+
     @classmethod
-    def create_checkout_session(cls, amount, description, success_url=None, cancel_url=None):
-        """
-        Creates a checkout session in PayMongo.
-        Amount should be in centavos (PHP * 100).
-        """
+    def create_checkout_session(cls, amount, description, order_id, success_url=None, cancel_url=None):
         url = f"{cls.BASE_URL}/checkout_sessions"
+        success_url = success_url or getattr(settings, "PAYMONGO_SUCCESS_URL", "")
+        cancel_url = cancel_url or getattr(settings, "PAYMONGO_CANCEL_URL", "")
 
         payload = {
             "data": {
                 "attributes": {
-                    "billing": {
-                        # Add default billing info if needed
-                    },
                     "line_items": [
                         {
-                            "amount": int(amount * 100),
+                            "amount": cls._to_centavos(amount),
                             "currency": "PHP",
                             "description": description,
                             "name": "Order Payment",
@@ -47,17 +49,26 @@ class PayMongoService:
                         }
                     ],
                     "payment_method_types": ["gcash", "paymaya", "card"],
-                    "description": description
+                    "description": description,
+                    "metadata": {
+                        "order_id": str(order_id),
+                        "platform": "sarig",
+                    },
                 }
             }
         }
+        if success_url:
+            payload["data"]["attributes"]["success_url"] = success_url
+        if cancel_url:
+            payload["data"]["attributes"]["cancel_url"] = cancel_url
 
         if getattr(settings, "PAYMONGO_USE_MOCK", settings.DEBUG):
             if cls._is_production_settings():
                 raise ImproperlyConfigured("PAYMONGO_USE_MOCK cannot be enabled in production.")
             return {
-                "id": "cs_mock_123456789",
-                "checkout_url": "https://checkout.paymongo.com/mock_session"
+                "id": f"cs_mock_{order_id}",
+                "checkout_url": "https://checkout.paymongo.com/mock_session",
+                "raw": payload["data"],
             }
 
         response = requests.post(url, json=payload, headers=cls.get_headers(), timeout=15)
@@ -81,7 +92,7 @@ class PayMongoService:
         payload = {
             "data": {
                 "attributes": {
-                    "amount": int(amount * 100),
+                    "amount": cls._to_centavos(amount),
                     "payment_id": payment_id,
                     "reason": reason,
                     "notes": "Order rejected by merchant"

--- a/apps/payments/tests.py
+++ b/apps/payments/tests.py
@@ -105,7 +105,8 @@ class PayMongoWebhookTests(TestCase):
             payment_id="pay_test_123",
         )
 
-        res = self._post_webhook(payload)
+        with self.captureOnCommitCallbacks(execute=True):
+            res = self._post_webhook(payload)
 
         self.assertEqual(res.status_code, 200)
         tx.refresh_from_db()

--- a/apps/payments/tests.py
+++ b/apps/payments/tests.py
@@ -1,3 +1,154 @@
-from django.test import TestCase
+import hashlib
+import hmac
+from decimal import Decimal
+from unittest.mock import patch
 
-# Create your tests here.
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+
+from apps.orders.models import Order, OrderStatus
+from apps.payments.models import PaymentMethod, PaymentStatus, PaymentTransaction
+from apps.users.models import User
+from apps.vendors.models import BusinessVertical, Store
+
+
+@override_settings(
+    PAYMONGO_WEBHOOK_SECRET="test_webhook_secret",
+    CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_STORE_EAGER_RESULT=False,
+    CELERY_BROKER_URL="memory://",
+    CELERY_RESULT_BACKEND="cache+memory://",
+)
+class PayMongoWebhookTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.customer = User.objects.create_user("paycust", "paycust@test.com", "pw12345")
+        self.merchant = User.objects.create_user("paymerch", "paymerch@test.com", "pw12345")
+        vertical = BusinessVertical.objects.create(name="Restaurant", slug="restaurant-payments")
+        self.store = Store.objects.create(
+            owner=self.merchant,
+            vertical=vertical,
+            name="Pay Store",
+            latitude=7.1,
+            longitude=125.4,
+            street_address="Addr",
+            city="Marawi",
+        )
+
+    def _create_order(self):
+        return Order.objects.create(
+            customer=self.customer,
+            store=self.store,
+            status=OrderStatus.PENDING,
+            delivery_address_text="Addr",
+            delivery_latitude=7.2,
+            delivery_longitude=125.5,
+            subtotal=Decimal("100"),
+            delivery_fee=Decimal("40"),
+            system_fee=Decimal("10"),
+            total_amount=Decimal("150"),
+        )
+
+    def _create_transaction(self, order):
+        return PaymentTransaction.objects.create(
+            order=order,
+            amount=order.total_amount,
+            payment_method=PaymentMethod.PAYMONGO,
+            status=PaymentStatus.PENDING,
+            external_transaction_id=f"cs_test_{order.id}",
+        )
+
+    def _post_webhook(self, payload):
+        import json
+
+        body = json.dumps(payload).encode("utf-8")
+        signature = hmac.new(
+            b"test_webhook_secret",
+            body,
+            hashlib.sha256,
+        ).hexdigest()
+        return self.client.post(
+            "/api/v1/payments/webhooks/paymongo/",
+            body,
+            content_type="application/json",
+            HTTP_PAYMONGO_SIGNATURE=signature,
+        )
+
+    def _event_payload(self, event_type, checkout_session_id, payment_id=None):
+        attributes = {
+            "type": "checkout_session",
+            "payments": [{"id": payment_id}] if payment_id else [],
+            "metadata": {"order_id": ""},
+        }
+        return {
+            "data": {
+                "attributes": {
+                    "type": event_type,
+                    "data": {
+                        "id": checkout_session_id,
+                        "attributes": attributes,
+                    },
+                }
+            }
+        }
+
+    @patch("apps.orders.tasks.auto_cancel_stale_order.apply_async")
+    @patch("apps.users.notifications.PushNotificationService.notify_new_order")
+    @patch("apps.catalog.services.InventoryService.deduct_stock_for_order")
+    def test_paid_webhook_marks_transaction_success(self, stock_mock, notify_mock, cancel_mock):
+        stock_mock.return_value = (True, "ok")
+        order = self._create_order()
+        tx = self._create_transaction(order)
+        payload = self._event_payload(
+            "checkout_session.payment.paid",
+            tx.external_transaction_id,
+            payment_id="pay_test_123",
+        )
+
+        res = self._post_webhook(payload)
+
+        self.assertEqual(res.status_code, 200)
+        tx.refresh_from_db()
+        order.refresh_from_db()
+        self.assertEqual(tx.status, PaymentStatus.SUCCESS)
+        self.assertEqual(tx.payment_id, "pay_test_123")
+        self.assertEqual(order.status, OrderStatus.PENDING)
+        stock_mock.assert_called_once_with(order.id)
+        notify_mock.assert_called_once()
+        cancel_mock.assert_called_once()
+
+    def test_failed_webhook_marks_transaction_failed_and_cancels_order(self):
+        order = self._create_order()
+        tx = self._create_transaction(order)
+        payload = self._event_payload("checkout_session.payment.failed", tx.external_transaction_id)
+
+        res = self._post_webhook(payload)
+
+        self.assertEqual(res.status_code, 200)
+        tx.refresh_from_db()
+        order.refresh_from_db()
+        self.assertEqual(tx.status, PaymentStatus.FAILED)
+        self.assertEqual(order.status, OrderStatus.CANCELLED)
+
+    def test_expired_webhook_marks_transaction_expired_and_cancels_order(self):
+        order = self._create_order()
+        tx = self._create_transaction(order)
+        payload = self._event_payload("checkout_session.expired", tx.external_transaction_id)
+
+        res = self._post_webhook(payload)
+
+        self.assertEqual(res.status_code, 200)
+        tx.refresh_from_db()
+        order.refresh_from_db()
+        self.assertEqual(tx.status, PaymentStatus.EXPIRED)
+        self.assertEqual(order.status, OrderStatus.CANCELLED)
+
+    def test_invalid_signature_is_rejected(self):
+        response = self.client.post(
+            "/api/v1/payments/webhooks/paymongo/",
+            {"data": {}},
+            format="json",
+            HTTP_PAYMONGO_SIGNATURE="bad",
+        )
+
+        self.assertEqual(response.status_code, 403)

--- a/apps/payments/views.py
+++ b/apps/payments/views.py
@@ -19,6 +19,10 @@ class PayMongoWebhookView(APIView):
     permission_classes = [AllowAny]
     throttle_scope = "payment_webhook"
 
+    PAID_EVENTS = {"payment.paid", "checkout_session.payment.paid"}
+    FAILED_EVENTS = {"payment.failed", "checkout_session.payment.failed"}
+    EXPIRED_EVENTS = {"checkout_session.expired", "checkout_session.payment.expired"}
+
     @transaction.atomic
     def post(self, request):
         raw_body = request.body
@@ -28,18 +32,15 @@ class PayMongoWebhookView(APIView):
         if not self._is_valid_signature(raw_body, signature):
             return Response({"error": "Unauthorized"}, status=403)
 
-        event_type = payload.get('data', {}).get('attributes', {}).get('type')
-        
-        # The structure of PayMongo webhook payload can vary depending on the event
-        # This is a simplified extraction
-        data_object = payload.get('data', {}).get('attributes', {}).get('data', {})
-        external_id = data_object.get('id')
+        event_type, data_object = self._extract_event(payload)
+        external_id = data_object.get("id")
+        payment_id = self._extract_payment_id(data_object)
 
         if not external_id:
             return Response({"error": "No ID found in payload"}, status=400)
 
         try:
-            payment_tx = PaymentTransaction.objects.get(external_transaction_id=external_id)
+            payment_tx = self._get_transaction(data_object, external_id, payment_id)
         except PaymentTransaction.DoesNotExist:
             return Response({"error": "Transaction not found"}, status=404)
 
@@ -47,12 +48,11 @@ class PayMongoWebhookView(APIView):
         payment_tx.provider_raw_response = payload
 
         # Idempotency Check: Don't process if already successful
-        if payment_tx.status == PaymentStatus.SUCCESS:
+        if payment_tx.status in {PaymentStatus.SUCCESS, PaymentStatus.REFUNDED}:
             return Response({"status": "Duplicate webhook ignored"}, status=200)
 
-        if event_type == 'payment.paid' or event_type == 'checkout_session.payment.paid':
+        if event_type in self.PAID_EVENTS:
             # Extract actual payment ID for future refunds
-            payment_id = data_object.get('attributes', {}).get('payment_id')
             if payment_id:
                 payment_tx.payment_id = payment_id
             
@@ -121,15 +121,56 @@ class PayMongoWebhookView(APIView):
                     reason="inventory_conflict",
                 )
 
-        elif event_type == 'payment.failed':
+        elif event_type in self.FAILED_EVENTS:
             payment_tx.status = PaymentStatus.FAILED
             payment_tx.save()
 
             order = payment_tx.order
             order.status = OrderStatus.CANCELLED
             order.save()
+            order.broadcast_status_update()
+
+        elif event_type in self.EXPIRED_EVENTS:
+            payment_tx.status = PaymentStatus.EXPIRED
+            payment_tx.save()
+
+            order = payment_tx.order
+            order.status = OrderStatus.CANCELLED
+            order.save()
+            order.broadcast_status_update()
 
         return Response({"status": "Webhook received"})
+
+    def _extract_event(self, payload):
+        event_attributes = payload.get("data", {}).get("attributes", {})
+        return event_attributes.get("type"), event_attributes.get("data", {})
+
+    def _extract_payment_id(self, data_object):
+        attributes = data_object.get("attributes", {})
+        payments = attributes.get("payments") or []
+        if attributes.get("payment_id"):
+            return attributes["payment_id"]
+        if payments and isinstance(payments[0], dict):
+            return payments[0].get("id")
+        if data_object.get("type") == "payment":
+            return data_object.get("id")
+        return None
+
+    def _get_transaction(self, data_object, external_id, payment_id):
+        transaction_qs = PaymentTransaction.objects.select_related("order", "order__store", "order__customer")
+        payment_tx = transaction_qs.filter(external_transaction_id=external_id).first()
+        if payment_tx:
+            return payment_tx
+        if payment_id:
+            payment_tx = transaction_qs.filter(payment_id=payment_id).first()
+            if payment_tx:
+                return payment_tx
+        order_id = data_object.get("attributes", {}).get("metadata", {}).get("order_id")
+        if order_id:
+            payment_tx = transaction_qs.filter(order_id=order_id, status=PaymentStatus.PENDING).first()
+            if payment_tx:
+                return payment_tx
+        raise PaymentTransaction.DoesNotExist
 
     def _attempt_refund_and_notify(self, payment_tx, customer, order_id, reason):
         if payment_tx.status == PaymentStatus.REFUNDED:

--- a/apps/payments/views.py
+++ b/apps/payments/views.py
@@ -104,7 +104,11 @@ class PayMongoWebhookView(APIView):
                 else:
                     # Schedule auto-cancellation in 5 minutes (if merchant doesn't accept manually)
                     from apps.orders.tasks import auto_cancel_stale_order
-                    auto_cancel_stale_order.apply_async((str(order.id),), countdown=600)
+                    transaction.on_commit(
+                        lambda: auto_cancel_stale_order.apply_async(
+                            (str(order.id),), countdown=600
+                        )
+                    )
             else:
                 # DISASTER AVERTED!
                 # The item sold out while they were paying GCash.

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -229,6 +229,8 @@ ENABLE_FCM_PUSH = os.getenv("ENABLE_FCM_PUSH", "False").lower() in {
 FCM_SERVER_KEY = os.getenv("FCM_SERVER_KEY", "")
 PAYMONGO_WEBHOOK_SECRET = os.getenv("PAYMONGO_WEBHOOK_SECRET", "")
 PAYMONGO_SECRET_KEY = os.getenv("PAYMONGO_SECRET_KEY", "")
+PAYMONGO_SUCCESS_URL = os.getenv("PAYMONGO_SUCCESS_URL", "")
+PAYMONGO_CANCEL_URL = os.getenv("PAYMONGO_CANCEL_URL", "")
 PAYMONGO_USE_MOCK = os.getenv("PAYMONGO_USE_MOCK", str(DEBUG)).lower() in {
     "1",
     "true",

--- a/docs/api/orders_api.md
+++ b/docs/api/orders_api.md
@@ -18,10 +18,7 @@ Base URL:
   "address_text": "string",
   "latitude": 0.0,
   "longitude": 0.0,
-  "subtotal": 0.0,
-  "delivery_fee": 0.0,
-  "system_fee": 0.0,
-  "total_amount": 0.0,
+  "delivery_method": "DELIVERY | PICKUP",
   "payment_method": "COD | PAYMONGO",
   "items": [
     {
@@ -32,6 +29,8 @@ Base URL:
   ]
 }
 ```
+
+Do not send `subtotal`, `delivery_fee`, `system_fee`, or `total_amount` from frontend logic. Checkout calculates these server-side. For `DELIVERY`, checkout uses the shared location service route estimate and delivery fee formula. For `PICKUP`, delivery fee is `0.00`.
 
 **Response (COD)**:
 ```json
@@ -51,6 +50,8 @@ Base URL:
 }
 ```
 
+For `PAYMONGO`, the merchant should not treat the order as paid from the frontend redirect alone. The backend waits for PayMongo webhook confirmation before marking the payment transaction as `SUCCESS` and notifying the merchant.
+
 ---
 
 ## ORDER TRACKING (Upcoming)
@@ -66,3 +67,5 @@ Base URL:
 ## NOTES
 - **Atomicity**: Checkout is wrapped in a database lock. If payment session creation fails, the order is not saved.
 - **Statuses**: `PENDING`, `ACCEPTED`, `PREPARING`, `READY`, `ON_THE_WAY`, `DELIVERED`, `CANCELLED`.
+- **Payment confirmation**: PayMongo orders remain payment-pending until `/api/v1/payments/webhooks/paymongo/` confirms paid, failed, or expired state.
+- **Delivery fee**: Delivery checkout uses `apps.locations` for road-distance estimates with Haversine fallback and rejects addresses outside `DELIVERY_MAX_DISTANCE_KM`.

--- a/docs/api/payments_api.md
+++ b/docs/api/payments_api.md
@@ -3,23 +3,150 @@
 Base URL:
 `http://localhost:8000/api/v1/payments/`
 
----
+## PayMongo MVP Scope
 
-## WEBHOOKS
+PayMongo is used as Sarig's external payment gateway for customer checkout. Sarig still owns order creation, merchant approval, inventory deduction, rider dispatch, refunds, and internal audit records.
 
-### PayMongo Webhook
-`POST /webhooks/paymongo/`
-**Public Access** (Verify signature in production)
+Current MVP payment methods:
+- `COD`: order is created immediately and merchant is notified immediately.
+- `PAYMONGO`: order is created with a pending payment transaction, then merchant notification waits for PayMongo webhook confirmation.
 
-**Functionality**:
-- Listens for `payment.paid` or `checkout_session.payment.paid`.
-- Finds the `PaymentTransaction` via `external_transaction_id`.
-- Updates `Order` status to `ACCEPTED`.
-- Triggers **Real-Time WebSocket** alert to the Merchant.
+Payment transaction statuses:
+- `PENDING`
+- `AUTHORIZED`
+- `SUCCESS`
+- `FAILED`
+- `EXPIRED`
+- `REFUNDED`
 
----
+## Environment
 
-## NOTES
-- **Audit Log**: Every webhook request is saved in `provider_raw_response` for debugging.
-- **Methods**: `COD`, `STRIPE`, `PAYMONGO`, `WALLET`.
-- **Transaction Statuses**: `PENDING`, `AUTHORIZED`, `SUCCESS`, `FAILED`, `REFUNDED`.
+Use PayMongo test mode for local and development testing.
+
+```env
+PAYMONGO_SECRET_KEY=sk_test_...
+PAYMONGO_WEBHOOK_SECRET=whsk_...
+PAYMONGO_SUCCESS_URL=http://localhost:3000/orders/payment/success
+PAYMONGO_CANCEL_URL=http://localhost:3000/orders/payment/cancelled
+PAYMONGO_USE_MOCK=False
+```
+
+Rules:
+- Use `sk_test_...` for development.
+- Do not use `sk_live_...` until production.
+- Keep secret keys in `.env`; do not commit them.
+- `PAYMONGO_USE_MOCK=True` skips PayMongo and returns a fake checkout URL.
+- `PAYMONGO_USE_MOCK=False` calls PayMongo's test API when using `sk_test_...`.
+
+## Checkout Flow
+
+PayMongo checkout is created from:
+
+`POST /api/v1/orders/checkout/`
+
+Required request field:
+
+```json
+{
+  "payment_method": "PAYMONGO"
+}
+```
+
+Successful response:
+
+```json
+{
+  "status": "pending",
+  "checkout_url": "https://checkout.paymongo.com/...",
+  "order": {}
+}
+```
+
+Backend behavior:
+- Creates the Sarig `Order`.
+- Creates a `PaymentTransaction` with `payment_method=PAYMONGO` and `status=PENDING`.
+- Creates a PayMongo checkout session.
+- Stores the PayMongo checkout session ID in `external_transaction_id`.
+- Stores provider metadata in `provider_raw_response`.
+- Returns `checkout_url` to web/mobile.
+
+## Webhook Endpoint
+
+Endpoint:
+
+`POST /api/v1/payments/webhooks/paymongo/`
+
+Local development requires a public HTTPS tunnel because PayMongo cannot call `127.0.0.1`.
+
+Example ngrok endpoint:
+
+```text
+https://your-ngrok-domain.ngrok-free.dev/api/v1/payments/webhooks/paymongo/
+```
+
+When using ngrok, add the ngrok host to `.env`:
+
+```env
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,your-ngrok-domain.ngrok-free.dev
+```
+
+PayMongo webhook events to enable:
+- `checkout_session.payment.paid`
+- `payment.paid`
+- `payment.failed`
+- `payment.refunded`
+- `payment.refund.updated`
+
+Current backend handling:
+- `checkout_session.payment.paid` or `payment.paid`:
+  - marks `PaymentTransaction.status=SUCCESS`
+  - stores `payment_id` when present
+  - deducts inventory
+  - notifies merchant
+  - keeps order `PENDING` for merchant approval unless store auto-accept is enabled
+- `payment.failed` or `checkout_session.payment.failed`:
+  - marks `PaymentTransaction.status=FAILED`
+  - cancels the order
+- `checkout_session.expired` or `checkout_session.payment.expired`:
+  - marks `PaymentTransaction.status=EXPIRED`
+  - cancels the order
+
+Webhook security:
+- Uses `PAYMONGO_WEBHOOK_SECRET` to verify `Paymongo-Signature`.
+- Saves raw webhook payload in `provider_raw_response`.
+- Ignores duplicate successful/refunded webhooks safely.
+- Resolves transactions by checkout session ID, payment ID, or order metadata.
+
+## Refund Behavior
+
+Refund calls are supported through `PayMongoService.create_refund`.
+
+Current refund triggers:
+- merchant rejects a paid PayMongo order
+- stale paid PayMongo order is auto-cancelled
+- paid webhook succeeds but inventory deduction fails
+
+When refund succeeds, the payment transaction becomes:
+
+```text
+REFUNDED
+```
+
+## Local Verification
+
+Run migrations:
+
+```bash
+python manage.py migrate
+```
+
+Run focused tests:
+
+```bash
+python manage.py test apps.payments tests.orders.test_checkout tests.orders.test_auto_cancel_refund tests.orders.test_merchant_actions --keepdb
+```
+
+Verified development behavior:
+- test PayMongo API creates a real checkout session when `PAYMONGO_USE_MOCK=False`
+- ngrok webhook URL reaches local Django
+- signed webhook updates `PaymentTransaction` and `Order` status correctly

--- a/tests/orders/test_checkout.py
+++ b/tests/orders/test_checkout.py
@@ -6,13 +6,14 @@ from apps.users.models import User, Role
 from apps.vendors.models import Store, BusinessVertical
 from apps.catalog.models import Category, Product
 from apps.orders.models import Order
-from apps.payments.models import PaymentTransaction, PaymentMethod
+from apps.payments.models import PaymentTransaction, PaymentMethod, PaymentStatus
 from apps.marketing.models import PromoCode, DiscountType
 from django.utils import timezone
 from datetime import timedelta
 
 
 @override_settings(
+    PAYMONGO_USE_MOCK=True,
     CELERY_TASK_ALWAYS_EAGER=True,
     CELERY_TASK_STORE_EAGER_RESULT=False,
     CELERY_RESULT_BACKEND="cache+memory://",
@@ -86,6 +87,30 @@ class CheckoutFlowTests(TestCase):
                 order=order, payment_method=PaymentMethod.COD
             ).exists()
         )
+
+    def test_paymongo_checkout_returns_checkout_url_and_records_session(self):
+        self.client.force_authenticate(user=self.customer)
+        payload = {
+            "store_id": str(self.store.id),
+            "items": [{"product_id": str(self.product.id), "quantity": 1}],
+            "payment_method": "PAYMONGO",
+            "delivery_method": "PICKUP",
+            "address_text": "Home",
+            "latitude": "7.190700",
+            "longitude": "125.455300",
+        }
+
+        res = self.client.post("/api/v1/orders/checkout/", payload, format="json")
+
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(res.data["status"], "pending")
+        self.assertIn("checkout_url", res.data)
+        order = Order.objects.get(id=res.data["order"]["id"])
+        tx = PaymentTransaction.objects.get(order=order)
+        self.assertEqual(tx.payment_method, PaymentMethod.PAYMONGO)
+        self.assertEqual(tx.status, PaymentStatus.PENDING)
+        self.assertTrue(tx.external_transaction_id.startswith("cs_mock_"))
+        self.assertEqual(tx.provider_raw_response["attributes"]["metadata"]["order_id"], str(order.id))
 
     def test_checkout_rejects_product_from_different_store(self):
         self.client.force_authenticate(user=self.customer)


### PR DESCRIPTION
- add PayMongo checkout metadata and redirect URL configuration
- store provider checkout response details on payment transactions
- add EXPIRED payment status and migration
- handle paid, failed, expired, duplicate, and refund webhook states
- reconcile webhook transactions by checkout session, payment ID, or order metadata
- keep paid PayMongo orders pending for merchant approval unless auto-accept is enabled
- cancel unpaid orders when PayMongo payment fails or expires
- document PayMongo test-mode setup, ngrok webhook flow, and payment behavior
- add checkout and webhook tests for PayMongo payment lifecycle